### PR TITLE
Modification to include missing sections in processor and template files

### DIFF
--- a/tugboat/site_processors/base.py
+++ b/tugboat/site_processors/base.py
@@ -33,3 +33,34 @@ class BaseProcessor:
 
     def render_template(self, template):
         pass
+
+    @staticmethod
+    def get_role_wise_nodes(yaml_data):
+        hosts = {
+            'genesis': {},
+            'masters': [],
+            'workers': [],
+        }
+        """
+        if self.hosts['masters'] is not None:
+            return self.hosts
+        """
+        for rack in yaml_data['baremetal']:
+            for host in yaml_data['baremetal'][rack]:
+                if yaml_data['baremetal'][rack][host][
+                        'type'] == 'genesis':
+                    hosts['genesis'] = {
+                        'name':
+                        host,
+                        'pxe':
+                        yaml_data['baremetal'][rack][host]['ip']['pxe'],
+                        'oam':
+                        yaml_data['baremetal'][rack][host]['ip']['oam'],
+                    }
+                elif yaml_data['baremetal'][rack][host][
+                        'type'] == 'controller':
+                    hosts['masters'].append(host)
+                else:
+                    hosts['workers'].append(host)
+        return hosts
+ 

--- a/tugboat/site_processors/network_processor.py
+++ b/tugboat/site_processors/network_processor.py
@@ -63,6 +63,17 @@ class NetworkProcessor:
                     hosts['workers'].append(host)
         return hosts
 
+    """ To get genesis ip we take the calico ip of the genesis node"""
+    def get_genesis_ip(self):
+        genesis_ip = '0.0.0.0'
+        for rack in self.yaml_data['baremetal']:
+            for host in self.yaml_data['baremetal'][rack]:
+                if self.yaml_data['baremetal'][rack][host][
+                        'type'] == 'genesis':
+                    genesis_ip = self.yaml_data['baremetal'][rack][host]['ip']['calico']
+
+        return genesis_ip
+
     def get_network_data(self):
         network_data = self.yaml_data['network']
         dns_servers = network_data['dns']['servers'].split(',')
@@ -89,7 +100,6 @@ class NetworkProcessor:
            'domain': 'dummy'
        }
 
-
         return {
             'dns_servers': dns_servers,
             'ntp_servers': ntp_servers,
@@ -98,12 +108,14 @@ class NetworkProcessor:
             'calico_vlan': calico_vlan,
             'bgp': bgp_data,
             'dns': network_data['dns'],
+            'genesis_ip':self.get_genesis_ip(),
             'ldap': ldap_fix
         }
 
     def get_conf_data(self):
         conf_data = self.yaml_data['conf']
         return { 'conf': conf_data }
+
 
     def render_template(self):
         template_software_dir = pkg_resources.resource_filename(

--- a/tugboat/site_processors/network_processor.py
+++ b/tugboat/site_processors/network_processor.py
@@ -83,6 +83,10 @@ class NetworkProcessor(BaseProcessor):
             'ntp_servers': ntp_servers,
             'proxy': proxy,
             'ceph_cidr': ' '.join(ceph_cidr),
+
+            """ calico gw is suppressed, will be opened after xl parser
+            'calico_gw': network_data['common']['calico']['gw'],
+            """
             'calico_vlan': calico_vlan,
             'bgp': bgp_data,
             'dns': network_data['dns'],

--- a/tugboat/site_processors/network_processor.py
+++ b/tugboat/site_processors/network_processor.py
@@ -173,7 +173,7 @@ class NetworkProcessor:
                         'dns']
                     try:
                         outfile = '{}{}.yaml'.format(outfile_dir,
-                                                     '/{}'.format(key))
+                                                     '{}'.format(key))
                         print('Rendering data for {}'.format(outfile))
                         out = open(outfile, "w")
                         # pylint: disable=maybe-no-member

--- a/tugboat/site_processors/network_processor.py
+++ b/tugboat/site_processors/network_processor.py
@@ -73,6 +73,23 @@ class NetworkProcessor:
             ceph_cidr.append(network_data['rack'][rack]['storage']['nw'])
         calico_vlan = network_data['rack'][rack]['calico']['vlan']
         bgp_data = network_data['bgp']
+
+        """ 
+		Dummy data to fill ldap details 
+        Code to added after xl parser fixes
+
+        """
+
+        ldap_fix = {
+           'base_url': 'dummy',
+           'url': 'dummy',
+           'auth_path': 'dummy',
+           'common_name': 'dummy',
+           'subdomain': 'dummy',
+           'domain': 'dummy'
+       }
+
+
         return {
             'dns_servers': dns_servers,
             'ntp_servers': ntp_servers,
@@ -80,7 +97,8 @@ class NetworkProcessor:
             'ceph_cidr': ' '.join(ceph_cidr),
             'calico_vlan': calico_vlan,
             'bgp': bgp_data,
-            'dns': network_data['dns']
+            'dns': network_data['dns'],
+            'ldap': ldap_fix
         }
 
     def get_conf_data(self):

--- a/tugboat/site_processors/network_processor.py
+++ b/tugboat/site_processors/network_processor.py
@@ -58,8 +58,11 @@ class NetworkProcessor(BaseProcessor):
         ntp_servers = network_data['ntp']['servers'].split(',')
         proxy = network_data['proxy']
         ceph_cidr = []
+        """
         for rack in network_data['rack']:
             ceph_cidr.append(network_data['rack'][rack]['storage']['nw'])
+        """
+        ceph_cidr.append(network_data['storage']['nw'])
         calico_vlan = network_data['rack'][rack]['calico']['vlan']
         bgp_data = network_data['bgp']
 

--- a/tugboat/templates/baremetal/bootaction.yaml.j2
+++ b/tugboat/templates/baremetal/bootaction.yaml.j2
@@ -65,10 +65,10 @@ metadata:
     - src:
         schema: pegleg/CommonAddresses/v1
         name: common-addresses
-        path: .calico.ip_rule.interface
+        path: .calico.ip_rule.gateway
       dest:
         path: .assets[0].data
-        pattern: DH_SUB_KSN_INTERFACE
+        pattern: DH_SUB_GATEWAY_IP
     - src:
         schema: pegleg/CommonAddresses/v1
         name: common-addresses
@@ -102,7 +102,7 @@ data:
 
         [Service]
         Type=simple
-        ExecStart=/opt/configure-ip-rules.sh -i DH_SUB_KSN_INTERFACE -c DH_SUB_POD_CIDR -s DH_SUB_INGRESS_CIDR
+        ExecStart=/opt/configure-ip-rules.sh -g DH_SUB_GATEWAY_IP -c DH_SUB_POD_CIDR -s DH_SUB_INGRESS_CIDR
 
         [Install]
         WantedBy=multi-user.target

--- a/tugboat/templates/networks/common_addresses.yaml.j2
+++ b/tugboat/templates/networks/common_addresses.yaml.j2
@@ -76,6 +76,14 @@ data:
   ntp:
     servers_joined: {{ data['network']['ntp_servers']|join(',') }}
 
+  ldap:
+    base_url: {{ data['network']['ldap']['base_url'] }}
+    url: {{ data['network']['ldap']['url'] }}
+    auth_path: {{ data['network']['ldap']['auth_path'] }}
+    common_name: {{ data['network']['ldap']['common_name'] }}
+    subdomain: {{ data['network']['ldap']['subdomain'] }}
+    domain: {{ data['network']['ldap']['domain'] }}
+
   domain:
     url: {{ data['network']['dns']['domain'] }}
 

--- a/tugboat/templates/networks/common_addresses.yaml.j2
+++ b/tugboat/templates/networks/common_addresses.yaml.j2
@@ -13,10 +13,10 @@ data:
     etcd:
       service_ip: 10.96.232.136
     ip_rule:
-      interface: bond1.{{ data['network']['calico_vlan']}}
+      interface: {{ data['network']['calico_gw']}}
     bgp:
       ipv4:
-        public_service_cidr: {{ data['conf']['ingress'] }}
+        public_service_cidr: {{ data['conf']['conf']['ingress'] }}
         peers:
 {% for peer in data['network']['bgp']['peers'] %}
           - {{ peer }}

--- a/tugboat/templates/networks/common_addresses.yaml.j2
+++ b/tugboat/templates/networks/common_addresses.yaml.j2
@@ -33,7 +33,7 @@ data:
 
   genesis:
     hostname: {{ data['hosts']['genesis']['name'] }}
-    ip: {{ data['hosts']['genesis']['oam'] }}
+    ip: {{ data['network']['genesis_ip'] }}
 
   bootstrap:
     ip: {{ data['hosts']['genesis']['pxe'] }}

--- a/tugboat/templates/networks/physical/rack.yaml.j2
+++ b/tugboat/templates/networks/physical/rack.yaml.j2
@@ -1,8 +1,9 @@
+{% for rack_key in data['rack'].keys()%}
 ---
 schema: 'drydock/NetworkLink/v1'
 metadata:
   schema: 'metadata/Document/v1'
-  name: {{ data['rack'] }}_oob
+  name: {{rack_key}}_oob
   layeringDefinition:
     abstract: false
     layer: site
@@ -16,15 +17,36 @@ data:
   linkspeed: auto
   trunking:
     mode: disabled
-    default_network: {{ data['rack'] }}_oob
+    default_network: {{rack_key}}_oob
   allowed_networks:
-    - {{ data['rack'] }}_oob
+    - {{rack_key}}_oob
 ...
 ---
+schema: 'drydock/Network/v1'
+metadata:
+  schema: 'metadata/Document/v1'
+  name: {{rack_key}}_oob
+  layeringDefinition:
+    abstract: false
+    layer: site
+  storagePolicy: cleartext
+data:
+  cidr: {{ data['rack'][rack_key]['oob']['nw'] }}
+  routes:
+    - subnet: '0.0.0.0/0'
+      gateway: {{ data['rack'][rack_key]['oob']['gw'] }}
+      metric: 100
+  ranges:
+    - type: static
+      start: {{ data['rack'][rack_key]['oob']['static_start'] }}
+      end: {{ data['rack'][rack_key]['oob']['static_end'] }}
+...
+---
+	  
 schema: 'drydock/NetworkLink/v1'
 metadata:
   schema: 'metadata/Document/v1'
-  name: {{ data['rack'] }}_pxe
+  name: {{rack_key}}_pxe
   layeringDefinition:
     abstract: false
     layer: site
@@ -36,187 +58,43 @@ data:
   linkspeed: auto
   trunking:
     mode: disabled
-    default_network: {{ data['rack'] }}_pxe
+    default_network: {{rack_key}}_pxe
   allowed_networks:
-    - {{ data['rack'] }}_pxe
-...
----
-schema: 'drydock/NetworkLink/v1'
-metadata:
-  schema: 'metadata/Document/v1'
-  name: {{ data['rack'] }}_bond1
-  layeringDefinition:
-    abstract: false
-    layer: site
-  storagePolicy: cleartext
-data:
-  bonding:
-    mode: 802.3ad
-    hash: layer3+4
-    peer_rate: fast
-    mon_rate: 100
-    up_delay: 1000
-    down_delay: 3000
-  mtu: 9100
-  linkspeed: auto
-  trunking:
-    mode: 802.1q
-  allowed_networks:
-    - {{ data['rack'] }}_oam
-    - {{ data['rack'] }}_storage
-    - {{ data['rack'] }}_overlay
-    - {{ data['rack'] }}_ksn
+    - {{rack_key}}_pxe
 ...
 ---
 schema: 'drydock/Network/v1'
 metadata:
   schema: 'metadata/Document/v1'
-  name: {{ data['rack'] }}_oob
+  name: {{rack_key}}_pxe
   layeringDefinition:
     abstract: false
     layer: site
   storagePolicy: cleartext
 data:
-  cidr: {{ data['oob']['nw'] }}
-  routes:
-    - subnet: '0.0.0.0/0'
-      gateway: {{ data['oob']['gw'] }}
-      metric: 100
-  ranges:
-    - type: static
-      start: {{ data['oob']['static_start'] }}
-      end: {{ data['oob']['static_end'] }}
-...
----
-schema: 'drydock/Network/v1'
-metadata:
-  schema: 'metadata/Document/v1'
-  name: {{ data['rack'] }}_pxe
-  layeringDefinition:
-    abstract: false
-    layer: site
-  storagePolicy: cleartext
-data:
-  cidr: {{ data['pxe']['nw'] }}
-{% if not data['is_genesis'] %}
+  cidr: {{ data['rack'][rack_key]['pxe']['nw'] }}
+{% if not data['rack'][rack_key]['is_genesis'] %}
   dhcp_relay:
     upstream_target: {{ data['dns']['dhcp_relay'] }}
 {% endif %}
   routes:
-{% if not data['is_genesis'] %}
+{% if not data['rack'][rack_key]['is_genesis'] %}
     - subnet: 0.0.0.0/0
-      gateway: {{ data['pxe']['gw'] }}
+      gateway: {{ data['rack'][rack_key]['pxe']['gw'] }}
       metric: 100
 {% endif %}
-{% for other_subnet in data['pxe']['routes'] %}
+{% for other_subnet in data['rack'][rack_key]['pxe']['routes'] %}
     - subnet: {{ other_subnet }}
-      gateway: {{ data['pxe']['gw'] }}
+      gateway: {{ data['rack'][rack_key]['pxe']['gw'] }}
       metric: 100
 {% endfor %}
   ranges:
     - type: 'static'
-      start: {{ data['pxe']['static_start'] }}
-      end: {{ data['pxe']['static_end'] }}
+      start: {{ data['rack'][rack_key]['pxe']['static_start'] }}
+      end: {{ data['rack'][rack_key]['pxe']['static_end'] }}
     - type: dhcp
-      start: {{ data['pxe']['dhcp_start'] }}
-      end: {{ data['pxe']['dhcp_end'] }}
+      start: {{ data['rack'][rack_key]['pxe']['dhcp_start'] }}
+      end: {{ data['rack'][rack_key]['pxe']['dhcp_end'] }}
 ...
 ---
-schema: 'drydock/Network/v1'
-metadata:
-  schema: 'metadata/Document/v1'
-  name: {{ data['rack'] }}_oam
-  layeringDefinition:
-    abstract: false
-    layer: 'site'
-  storagePolicy: cleartext
-data:
-  vlan: {{ data['oam']['vlan'] }}
-  mtu: 9100
-  cidr: {{ data['oam']['nw'] }}
-  routes:
-{% for route in data['oam']['routes'] %}
-    - subnet: {{ route }}
-      gateway: {{ data['oam']['gw'] }}
-      metric: 100
-{% endfor %}
-  ranges:
-    - type: static
-      start: {{ data['oam']['static_start'] }}
-      end: {{ data['oam']['static_end'] }}
-  dns:
-    domain: {{ data['dns']['domain'] }}
-    servers: {{ data['dns']['servers'] }}
-...
----
-schema: 'drydock/Network/v1'
-metadata:
-  schema: 'metadata/Document/v1'
-  name: {{ data['rack'] }}_storage
-  layeringDefinition:
-    abstract: false
-    layer: site
-  storagePolicy: cleartext
-data:
-  vlan: {{ data['storage']['vlan'] }}
-  mtu: 9100
-  cidr: {{ data['storage']['nw'] }}
-  routes:
-{% for route in data['storage']['routes'] %}
-    - subnet: {{ route }}
-      gateway: {{ data['storage']['gw'] }}
-      metric: 100
-{% endfor %}
-  ranges:
-    - type: static
-      start: {{ data['storage']['static_start'] }}
-      end: {{ data['storage']['static_end'] }}
-...
----
-schema: 'drydock/Network/v1'
-metadata:
-  schema: 'metadata/Document/v1'
-  name: {{ data['rack'] }}_overlay
-  layeringDefinition:
-    abstract: false
-    layer: site
-  storagePolicy: cleartext
-data:
-  vlan: {{ data['overlay']['vlan'] }}
-  mtu: 9100
-  cidr: {{ data['overlay']['nw'] }}
-  routes:
-{% for route in data['overlay']['routes'] %}
-    - subnet: {{ route }}
-      gateway: {{ data['overlay']['gw'] }}
-      metric: 100
-{% endfor %}
-  ranges:
-    - type: static
-      start: {{ data['overlay']['static_start'] }}
-      end: {{ data['overlay']['static_end'] }}
-...
----
-schema: 'drydock/Network/v1'
-metadata:
-  schema: 'metadata/Document/v1'
-  name: {{ data['rack'] }}_ksn
-  layeringDefinition:
-    abstract: false
-    layer: site
-  storagePolicy: cleartext
-data:
-  vlan: {{ data['calico']['vlan'] }}
-  mtu: 9100
-  cidr: {{ data['calico']['nw'] }}
-  routes:
-{% for route in data['calico']['routes'] %}
-    - subnet: {{ route }}
-      gateway: {{ data['calico']['gw'] }}
-      metric: 100
-{% endfor %}
-  ranges:
-    - type: static
-      start: {{ data['calico']['static_start'] }}
-      end: {{ data['calico']['static_end'] }}
-...
+{%endfor%}

--- a/tugboat/templates/networks/physical/rack_common.yaml.j2
+++ b/tugboat/templates/networks/physical/rack_common.yaml.j2
@@ -1,0 +1,126 @@
+---
+schema: 'drydock/NetworkLink/v1'
+metadata:
+  schema: 'metadata/Document/v1'
+  name: {{ data['region_name'] }}_bond1
+  layeringDefinition:
+    abstract: false
+    layer: site
+  storagePolicy: cleartext
+data:
+  bonding:
+    mode: 802.3ad
+    hash: layer3+4
+    peer_rate: fast
+    mon_rate: 100
+    up_delay: 1000
+    down_delay: 3000
+  mtu: 9100
+  linkspeed: auto
+  trunking:
+    mode: 802.1q
+  allowed_networks:
+    - {{ data['region_name'] }}_oam
+    - {{ data['region_name'] }}_storage
+    - {{ data['region_name'] }}_overlay
+    - {{ data['region_name'] }}_ksn
+...
+---
+schema: 'drydock/Network/v1'
+metadata:
+  schema: 'metadata/Document/v1'
+  name: {{ data['region_name'] }}_oam
+  layeringDefinition:
+    abstract: false
+    layer: 'site'
+  storagePolicy: cleartext
+data:
+  vlan: {{ data['common']['oam']['vlan'] }}
+  mtu: 9100
+  cidr: {{ data['common']['oam']['nw'] }}
+  routes:
+{% for route in data['common']['oam']['routes'] %}
+    - subnet: {{ route }}
+      gateway: {{ data['common']['oam']['gw'] }}
+      metric: 100
+{% endfor %}
+  ranges:
+    - type: static
+      start: {{ data['common']['oam']['static_start'] }}
+      end: {{ data['common']['oam']['static_end'] }}
+  dns:
+    domain: {{ data['common']['dns']['domain'] }}
+    servers: {{ data['common']['dns']['servers'] }}
+...
+---
+schema: 'drydock/Network/v1'
+metadata:
+  schema: 'metadata/Document/v1'
+  name: {{ data['region_name'] }}_storage
+  layeringDefinition:
+    abstract: false
+    layer: site
+  storagePolicy: cleartext
+data:
+  vlan: {{ data['common']['storage']['vlan'] }}
+  mtu: 9100
+  cidr: {{ data['common']['storage']['nw'] }}
+  routes:
+{% for route in data['common']['storage']['routes'] %}
+    - subnet: {{ route }}
+      gateway: {{ data['common']['storage']['gw'] }}
+      metric: 100
+{% endfor %}
+  ranges:
+    - type: static
+      start: {{ data['common']['storage']['static_start'] }}
+      end: {{ data['common']['storage']['static_end'] }}
+...
+---
+schema: 'drydock/Network/v1'
+metadata:
+  schema: 'metadata/Document/v1'
+  name: {{ data['region_name'] }}_overlay
+  layeringDefinition:
+    abstract: false
+    layer: site
+  storagePolicy: cleartext
+data:
+  vlan: {{ data['common']['overlay']['vlan'] }}
+  mtu: 9100
+  cidr: {{ data['common']['overlay']['nw'] }}
+  routes:
+{% for route in data['common']['overlay']['routes'] %}
+    - subnet: {{ route }}
+      gateway: {{ data['common']['overlay']['gw'] }}
+      metric: 100
+{% endfor %}
+  ranges:
+    - type: static
+      start: {{ data['common']['overlay']['static_start'] }}
+      end: {{ data['common']['overlay']['static_end'] }}
+...
+---
+schema: 'drydock/Network/v1'
+metadata:
+  schema: 'metadata/Document/v1'
+  name: {{ data['region_name'] }}_ksn
+  layeringDefinition:
+    abstract: false
+    layer: site
+  storagePolicy: cleartext
+data:
+  vlan: {{ data['common']['calico']['vlan'] }}
+  mtu: 9100
+  cidr: {{ data['common']['calico']['nw'] }}
+  routes:
+{% for route in data['common']['calico']['routes'] %}
+    - subnet: {{ route }}
+      gateway: {{ data['common']['calico']['gw'] }}
+      metric: 100
+{% endfor %}
+  ranges:
+    - type: static
+      start: {{ data['common']['calico']['static_start'] }}
+      end: {{ data['common']['calico']['static_end'] }}
+...

--- a/tugboat/templates/profiles/genesis.yaml.j2
+++ b/tugboat/templates/profiles/genesis.yaml.j2
@@ -36,4 +36,5 @@ data:
       - openstack-control-plane=enabled
       - openvswitch=enabled
       - openstack-l3-agent=enabled
+      - node-exporter=enabled
 ...

--- a/tugboat/templates/software/charts/osh/openstack-compute-kit/neutron.yaml.j2
+++ b/tugboat/templates/software/charts/osh/openstack-compute-kit/neutron.yaml.j2
@@ -14,9 +14,17 @@ metadata:
       - method: merge
         path: .
   storagePolicy: cleartext
+  replacement: true
 data:
   values:
+    labels:
+      sriov:
+        node_selector_key: sriov
+        node_selector_value: enabled
     network:
+      backend:
+        - openvswitch
+        - sriov
       auto_bridge_add:
         br-bond1: bond1
       interface:
@@ -35,8 +43,13 @@ data:
         sriov_agent:
           sriov_nic:
             physical_device_mappings: sriovnet1:enp59s0f0,sriovnet2:enp216s0f1
+            exclude_devices: null
+          securitygroup:
+            firewall_driver: neutron.agent.firewall.NoopFirewallDriver
 {% if data['conf']['neutron']['network_vlan_ranges'] %}
         ml2_conf:
+	  ml2:
+            mechanism_drivers: l2population,openvswitch,sriovnicswitch
           ml2_type_vlan:
             network_vlan_ranges: {{ data['conf']['neutron']['network_vlan_ranges'] }}
 {% endif %}


### PR DESCRIPTION
The following fixes are made:
- fixed params to configure-ip-rules.sh
- Adding dummy ldap section in common-addresses
- Fix genesis ip setting
- Adding dummy ldap section in common-addresses
- Added label node-exporter=enabled
- Adding missing section to neutron yaml file
- remove additional slash in log( minor).

Important:
For LDAP, temporary changes made to network processor
which will be reverted once we make  parser changes
to include a common section and also include LDAP
section.